### PR TITLE
Issue solved - Add sourcemap for webpack #61

### DIFF
--- a/lib/plugins/templates/lib/shared/nodejs/lib/webpack/functions/cloud.js
+++ b/lib/plugins/templates/lib/shared/nodejs/lib/webpack/functions/cloud.js
@@ -3,6 +3,7 @@ const nodeExternals = require('webpack-node-externals');
 module.exports = {
   target: 'node',
   externals: [nodeExternals()],
+  devtool: 'source-map',
   module: {
     loaders: [{
       test: /\.js$/,

--- a/lib/plugins/templates/lib/shared/nodejs/lib/webpack/functions/development.js
+++ b/lib/plugins/templates/lib/shared/nodejs/lib/webpack/functions/development.js
@@ -4,6 +4,7 @@ const nodeExternals = require('webpack-node-externals');
 module.exports = {
   target: 'node',
   externals: [nodeExternals()],
+  devtool: 'source-map',
   module: {
     loaders: [{
       test: /\.js$/,


### PR DESCRIPTION
#### Source map is added to webpack

* The Webpack devtools are set to generate sourcemap.
* 2/2 webpack function files were modified to add devtools functionalities.
* Errors will be displayed with line numbers of original files, hence easing down debugging.
* Devtool setting can be changed from "source-map" to "eval-source-map" for faster development and testing purposes.

"Simplest solutions are usually the correct ones."